### PR TITLE
Show distinct layers for missing, suppressed, present prevalence values

### DIFF
--- a/PQViz.ipynb
+++ b/PQViz.ipynb
@@ -220,8 +220,9 @@
     "display(tag)\n",
     "\n",
     "style = dict(description_width=\"150px\")\n",
-    "demographic_type = \"sex\"\n",
+    "demographic_type = \"zcta3\"\n",
     "demo_drop_down = widgets.Dropdown(options=[\"sex\", \"race\", \"age\", \"zcta3\"],\n",
+    "                                  value=demographic_type,\n",
     "                                  description=\"Demographic Type:\",\n",
     "                                  disabled=False,\n",
     "                                  style=style)\n",
@@ -235,7 +236,8 @@
     "\n",
     "selected_state = \"NC\"\n",
     "state_options = sorted([(s.name, s.abbr) for s in us.STATES])\n",
-    "state_drop_down = widgets.Dropdown(options= state_options,\n",
+    "state_drop_down = widgets.Dropdown(options=state_options,\n",
+    "                                   value=selected_state,\n",
     "                                   description=\"State:\",\n",
     "                                   disabled=False,\n",
     "                                   style=style)\n",
@@ -476,18 +478,16 @@
     "\n",
     "Note that the map below will show values grouped at the ZCTA3 level, rather than the finer-grained ZCTA5 level shown in the CDC PLACES data in the map directly above.\n",
     "\n",
-    "Areas of the map that are not filled in represent ZCTA3 areas with suppressed data."
+    "Areas of the map filled with light grey represent ZCTA3 areas without values present in the data. Areas filled with  dark grey represent ZCTA3 areas with suppressed data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "category_options = sorted(prev_data.loc[prev_data['Prevalence'].notna()]['Weight Category'].unique())\n",
+    "category_options = sorted(prev_data['Weight Category'].unique())\n",
     "category_dropdown = widgets.Dropdown(options=category_options,\n",
     "                                     description=\"Weight Category:\",\n",
     "                                     disabled=False,\n",

--- a/PQViz.py
+++ b/PQViz.py
@@ -145,8 +145,9 @@ To show/hide this cell's raw code input, click <a href="javascript:code_toggle()
 display(tag)
 
 style = dict(description_width="150px")
-demographic_type = "sex"
+demographic_type = "zcta3"
 demo_drop_down = widgets.Dropdown(options=["sex", "race", "age", "zcta3"],
+                                  value=demographic_type,
                                   description="Demographic Type:",
                                   disabled=False,
                                   style=style)
@@ -160,7 +161,8 @@ demo_drop_down.observe(dropdown_handler_demo, names="value")
 
 selected_state = "NC"
 state_options = sorted([(s.name, s.abbr) for s in us.STATES])
-state_drop_down = widgets.Dropdown(options= state_options,
+state_drop_down = widgets.Dropdown(options=state_options,
+                                   value=selected_state,
                                    description="State:",
                                    disabled=False,
                                    style=style)
@@ -327,12 +329,12 @@ interact(maps.choropleth_map_places, selected_state=fixed(selected_state), selec
 # 
 # Note that the map below will show values grouped at the ZCTA3 level, rather than the finer-grained ZCTA5 level shown in the CDC PLACES data in the map directly above.
 # 
-# Areas of the map that are not filled in represent ZCTA3 areas with suppressed data.
+# Areas of the map filled with light grey represent ZCTA3 areas without values present in the data. Areas filled with  dark grey represent ZCTA3 areas with suppressed data.
 
 # In[ ]:
 
 
-category_options = sorted(prev_data.loc[prev_data['Prevalence'].notna()]['Weight Category'].unique())
+category_options = sorted(prev_data['Weight Category'].unique())
 category_dropdown = widgets.Dropdown(options=category_options,
                                      description="Weight Category:",
                                      disabled=False,

--- a/pqviz/check_suppressed.py
+++ b/pqviz/check_suppressed.py
@@ -1,11 +1,12 @@
-import pandas as pd
-import numpy as np
-import seaborn as sns
-import matplotlib.pyplot as plt
 import glob
+from pathlib import Path
+
 from ipywidgets import interact, interactive, fixed, interact_manual
 import ipywidgets as widgets
-from pathlib import Path
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
 
 
 def check_suppressed(df, attribute):
@@ -23,3 +24,23 @@ def check_suppressed(df, attribute):
             columns={"Prevalence": "Number of subpopulations with suppressed values"}
         )
         return suppressed_values
+
+
+def suppressed_zcta3(df, category, prevalence_type):
+    """
+    Return an array of suppressed ZCTA3 values for the specified category and
+    prevalence type suppressed zcta3s.
+
+    Parameters:
+    df: DataFrame of prevalence data
+    category: Weight category/class
+    prevalence_type: Prevalence type, one of ['Age-Adjusted', 'Crude', 'Weighted']
+
+    Returns:
+    A numpy array of ZCTA3s with suppressed prevalence values.
+    """
+    return df.loc[
+        (df["Weight Category"] == category)
+        & (df["Prevalence type"] == prevalence_type)
+        & (df["Prevalence"].isna())
+    ]["zcta3"].values.tolist()

--- a/pqviz/maps.py
+++ b/pqviz/maps.py
@@ -259,7 +259,7 @@ def choropleth_map_pq(selected_state="NC", df=None, category="", prevalence_type
 
     base_layer = GeoJSON(
         data=state_gj,
-        style={"opacity": 0.8, "color": "black", "weight": 0.5, "fillOpacity": 0.1},
+        style={"opacity": 0.8, "color": "black", "weight": 0.8, "fillOpacity": 0.1},
         hover_style={"fillColor": "blue", "fillOpacity": 0.5},
     )
     base_layer.on_click(base_click_handler)


### PR DESCRIPTION
In the PQ choropleth, only ZCTA5s with non-suppressed, present prevalence values for ZCTA3 were shown previously. This update adds all three distinct layers. 

Need to assess whether the two non-present layers are represented sufficiently distinctly. Adding a pattern such as a cross-hatch or dots looks like it might be a big lift.